### PR TITLE
Add configurable AI defaults

### DIFF
--- a/src/ai/ai.ts
+++ b/src/ai/ai.ts
@@ -1,4 +1,4 @@
-import { AI_CONFIG, WHITE, BLACK } from './config';
+import { AI_CONFIG, DEFAULT_AI_CONFIG, WHITE, BLACK } from './config';
 import { getAllValidMoves, simulateMove } from '../logic/game';
 
 // transposition table (for minimax)
@@ -9,7 +9,12 @@ export function cpuMove(
   turn: 1 | 2,
   level: number
 ): { x: number; y: number; flips: [number, number][] } | null {
-  const config = AI_CONFIG[level] || AI_CONFIG[1];
+  const base = AI_CONFIG[level] || AI_CONFIG[1];
+  const config: any = {
+    ...DEFAULT_AI_CONFIG,
+    ...base,
+    endgame: { ...DEFAULT_AI_CONFIG.endgame, ...(base.endgame || {}) }
+  };
   const evalFunc = (b: number[][]) => config.evaluator(b, turn, config);
   const emptyCount = board.flat().filter(c => c === 0).length;
 
@@ -20,7 +25,7 @@ export function cpuMove(
   if (config.type === 'minimax') {
     const depth = config.dynamicDepth
       ? getDynamicDepth(emptyCount, config.depthTable || [])
-      : config.depth || 2;
+      : config.depth ?? DEFAULT_AI_CONFIG.depth ?? 2;
 
     return getBestMoveMinimax(board, turn, depth, evalFunc, config);
   }

--- a/src/ai/config.ts
+++ b/src/ai/config.ts
@@ -22,6 +22,32 @@ export const TIMING_CONFIG = {
 };
 
 // ========================
+// AIデフォルト設定
+// ========================
+
+export const DEFAULT_AI_CONFIG: Partial<AIConfig> = {
+  visible: true,
+  depth: 2,
+  weights: [
+    [100, -25, 10, 5, 5, 10, -25, 100],
+    [-25, -50, 1, 1, 1, 1, -50, -25],
+    [10, 1, 3, 2, 2, 3, 1, 10],
+    [5, 1, 2, 1, 1, 2, 1, 5],
+    [5, 1, 2, 1, 1, 2, 1, 5],
+    [10, 1, 3, 2, 2, 3, 1, 10],
+    [-25, -50, 1, 1, 1, 1, -50, -25],
+    [100, -25, 10, 5, 5, 10, -25, 100]
+  ],
+  parityWeight: 40,
+  stableStoneBonus: 20,
+  xSquarePenalty: 30,
+  trapPenalty: 30,
+  endgame: {
+    maxEmpty: 12,
+    usePruning: true,
+  },
+};
+// ========================
 // AIレベル定義
 // ========================
 
@@ -54,6 +80,7 @@ export interface AIConfig {
     usePruning: boolean;
   };
 }
+
 
 export const AI_CONFIG: { [level: number]: AIConfig } = {
   1: {

--- a/src/ai/evaluators.ts
+++ b/src/ai/evaluators.ts
@@ -1,16 +1,5 @@
-import { SIZE, EMPTY, BLACK, WHITE } from './config';
+import { SIZE, EMPTY, BLACK, WHITE, DEFAULT_AI_CONFIG } from './config';
 
-// デフォルトの重みマトリクス
-export const DEFAULT_WEIGHTS: number[][] = [
-  [100, -25, 10, 5, 5, 10, -25, 100],
-  [-25, -50, 1, 1, 1, 1, -50, -25],
-  [10, 1, 3, 2, 2, 3, 1, 10],
-  [5, 1, 2, 1, 1, 2, 1, 5],
-  [5, 1, 2, 1, 1, 2, 1, 5],
-  [10, 1, 3, 2, 2, 3, 1, 10],
-  [-25, -50, 1, 1, 1, 1, -50, -25],
-  [100, -25, 10, 5, 5, 10, -25, 100]
-];
 
 type Board = number[][];
 
@@ -73,31 +62,30 @@ export function evaluateBoard(board: Board, color: number): number {
 
 // 2. 戦略評価（固定重み）
 export function evaluateStrategicBoard(board: Board, color: number, config: any = {}): number {
-  return evaluateStrategicGeneralBoard(board, color, config, true);
+  return evaluateStrategicGeneralBoard(board, color, config);
 }
 
 // 3. 戦略評価（調整パラメータあり）
 export function evaluateStrategicAdvancedBoard(board: Board, color: number, config: any = {}): number {
-  return evaluateStrategicGeneralBoard(board, color, config, false);
+  return evaluateStrategicGeneralBoard(board, color, config);
 }
 
 // 内部共通評価関数
 function evaluateStrategicGeneralBoard(
   board: Board,
   color: number,
-  config: any = {},
-  useDefaults = true
+  config: any = {}
 ): number {
   const opponent = 3 - color;
   let score = 0;
 
-  const weights = config.weights || DEFAULT_WEIGHTS;
+  const weights = config.weights ?? DEFAULT_AI_CONFIG.weights;
   const useWeights = config.useWeights !== false;
 
-  const stableBonus = useDefaults ? 20 : config.stableStoneBonus ?? 20;
-  const parityBonus = useDefaults ? 40 : config.parityWeight ?? 40;
-  const xPenalty = useDefaults ? 30 : config.xSquarePenalty ?? 50;
-  const trapPenalty = useDefaults ? 30 : config.trapPenalty ?? 30;
+  const stableBonus = config.stableStoneBonus ?? DEFAULT_AI_CONFIG.stableStoneBonus;
+  const parityBonus = config.parityWeight ?? DEFAULT_AI_CONFIG.parityWeight;
+  const xPenalty = config.xSquarePenalty ?? DEFAULT_AI_CONFIG.xSquarePenalty;
+  const trapPenalty = config.trapPenalty ?? DEFAULT_AI_CONFIG.trapPenalty;
 
   // 重みスコア
   if (useWeights) {


### PR DESCRIPTION
## Summary
- consolidate default AI parameters into a single `DEFAULT_AI_CONFIG`
- import unified default config in evaluators
- adjust strategic evaluation to rely on `DEFAULT_AI_CONFIG`
- position `DEFAULT_AI_CONFIG` immediately after the section comment in `config.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68529418d4508330be7c7b75124b4b5a