### PR TITLE
Add timestamp to CPU vs CPU results filename

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,13 +399,15 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
 黒の勝率: ${((stats.blackWins / stats.games) * 100).toFixed(0)}%`;
 
     const download = () => {
+      if (!window.confirm('結果をダウンロードしますか？')) return;
+
       const blob = new Blob([summary], { type: 'text/plain' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
       const now = new Date();
       const pad = (n: number) => String(n).padStart(2, '0');
-      const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
       a.download = `cpu_vs_cpu_result_${timestamp}.txt`;
       a.click();
       URL.revokeObjectURL(url);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,7 +403,10 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = 'cpu_vs_cpu_result.txt';
+      const now = new Date();
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      a.download = `cpu_vs_cpu_result_${timestamp}.txt`;
       a.click();
       URL.revokeObjectURL(url);
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,7 +408,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
       const now = new Date();
       const pad = (n: number) => String(n).padStart(2, '0');
       const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
-      a.download = `cpu_vs_cpu_result_${timestamp}.txt`;
+      a.download = `cvc_result_${timestamp}.txt`;
       a.click();
       URL.revokeObjectURL(url);
     };


### PR DESCRIPTION
## Summary
- add timestamp to CPU vs CPU result file name when downloading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS2307 Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6852dd0358088330870979c016b2ad0a