### PR TITLE
Add score board to CPU mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,6 +542,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
   }
 
   if (mode === 'cpu' || mode === 'pvp' || mode === 'cpu-cpu' || mode === 'online') {
+    const { black: blackCount, white: whiteCount } = countStones(board);
     return (
       <div>
         <h1>オセロ</h1>
@@ -555,6 +556,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
             : `CPU vs CPU ${currentMatch}/${numMatches}（${AI_CONFIG[cpu1Level]?.name} vs ${AI_CONFIG[cpu2Level]?.name}）`}
         </p>
         <Board board={board} validMoves={gameOver ? [] : validMoves} onCellClick={handleClick} />
+        <p id="score-board">黒:{blackCount} 白:{whiteCount}</p>
         <p>{message}</p>
         {mode === 'online' && !gameOver && (
           <button onClick={giveUpOnline}>降参</button>

--- a/src/style.css
+++ b/src/style.css
@@ -99,3 +99,9 @@ td {
   font-size: 18px;
   margin-top: 20px;
 }
+
+#score-board {
+  font-size: 18px;
+  margin-top: 10px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- show current stone counts during CPU matches
- style score board

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685603e4370c8330a8b10af8e5001995