### PR TITLE
Add placement and flip animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ function App() {
       animTimerRef.current = null;
       setAnimations({ placed: undefined, flips: [] });
     }
+    setValidMoves([]); // hide hints during animation
     const flips = flipsRaw
       .map(([fx, fy]) => ({ x: fx, y: fy, dist: Math.abs(fx - placed.x) + Math.abs(fy - placed.y) }))
       .sort((a, b) => a.dist - b.dist)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ function App() {
   const [cpuThinking, setCpuThinking] = useState(false);
   const randomRef = useRef<boolean>(false);
   const prevOnlineBoardRef = useRef<Cell[][]>([]);
+  const animTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [animations, setAnimations] = useState<BoardAnimation>({ placed: undefined, flips: [] });
   const [animating, setAnimating] = useState(false);
 
@@ -93,15 +94,19 @@ function App() {
     placed: { x: number; y: number },
     flipsRaw: [number, number][]
   ) => {
+    if (animTimerRef.current) {
+      clearTimeout(animTimerRef.current);
+    }
     const flips = flipsRaw
       .map(([fx, fy]) => ({ x: fx, y: fy, dist: Math.abs(fx - placed.x) + Math.abs(fy - placed.y) }))
       .sort((a, b) => a.dist - b.dist)
       .map((c, idx) => ({ x: c.x, y: c.y, delay: idx * 100 }));
     setAnimations({ placed, flips });
     setAnimating(true);
-    setTimeout(() => {
+    animTimerRef.current = setTimeout(() => {
       setAnimations({ placed: undefined, flips: [] });
       setAnimating(false);
+      animTimerRef.current = null;
     }, flips.length * 100 + 400);
   };
 
@@ -154,7 +159,7 @@ function App() {
     } else if (mode === 'online') {
       const initial = onlineState.board.length ? onlineState.board : createInitialBoard();
       setBoard(initial);
-      prevOnlineBoardRef.current = initial;
+      prevOnlineBoardRef.current = initial.map(row => [...row]);
       setTurn(onlineState.turn);
       setGameOver(onlineState.gameOver);
       if (onlineState.waiting) {
@@ -188,7 +193,7 @@ function App() {
       if (placed) startAnimation(placed, flips);
     }
     setBoard(newBoard);
-    prevOnlineBoardRef.current = newBoard;
+    prevOnlineBoardRef.current = newBoard.map(row => [...row]);
     setTurn(onlineState.turn);
     setGameOver(onlineState.gameOver);
     if (onlineState.waiting) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,8 @@ function App() {
   ) => {
     if (animTimerRef.current) {
       clearTimeout(animTimerRef.current);
+      animTimerRef.current = null;
+      setAnimations({ placed: undefined, flips: [] });
     }
     const flips = flipsRaw
       .map(([fx, fy]) => ({ x: fx, y: fy, dist: Math.abs(fx - placed.x) + Math.abs(fy - placed.y) }))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,15 @@ function App() {
     if (gameOver || animating) return;
     if (mode === 'online') {
       if (turn !== onlineState.myColor) return;
+      const move = onlineState.validMoves.find(m => m.x === x && m.y === y);
+      if (!move) return;
+      const newBoard = board.map(row => [...row]);
+      newBoard[y][x] = turn;
+      move.flips.forEach(([fx, fy]) => newBoard[fy][fx] = turn);
+      setBoard(newBoard);
+      prevOnlineBoardRef.current = newBoard.map(row => [...row]);
+      startAnimation({ x, y }, move.flips);
+      setTurn(3 - turn as 1 | 2);
       sendOnlineMove(x, y);
       return;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,6 +216,11 @@ function App() {
   useEffect(() => {
     if (gameOver) return;
 
+    if (animating) {
+      setValidMoves([]);
+      return;
+    }
+
     if (mode === 'online') {
       setValidMoves(onlineState.validMoves);
       return;
@@ -243,7 +248,7 @@ function App() {
         setMessage(`${turn === 1 ? "黒" : "白"}の番です`);
       }
     }
-  }, [turn, board, gameOver, mode, actualPlayerColor, onlineState.validMoves]);
+  }, [turn, board, gameOver, mode, actualPlayerColor, onlineState.validMoves, animating]);
 
   useEffect(() => {
     if ((mode !== 'cpu' && mode !== 'cpu-cpu') || gameOver || cpuThinking || animating) return;

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -18,11 +18,12 @@ interface BoardProps {
   validMoves: { x: number; y: number }[];
   onCellClick: (x: number, y: number) => void;
   animations?: BoardAnimation;
+  disabled?: boolean;
 }
 
-const Board: React.FC<BoardProps> = ({ board, validMoves, onCellClick, animations }) => {
+const Board: React.FC<BoardProps> = ({ board, validMoves, onCellClick, animations, disabled }) => {
   return (
-    <table id="board">
+    <table id="board" style={{ pointerEvents: disabled ? 'none' : 'auto' }}>
       <tbody>
         {board.map((row, y) => (
           <tr key={y}>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,13 +2,25 @@
 
 type Cell = 0 | 1 | 2;
 
+interface FlipAnim {
+  x: number;
+  y: number;
+  delay: number;
+}
+
+interface BoardAnimation {
+  placed?: { x: number; y: number };
+  flips: FlipAnim[];
+}
+
 interface BoardProps {
   board: Cell[][];
   validMoves: { x: number; y: number }[];
   onCellClick: (x: number, y: number) => void;
+  animations?: BoardAnimation;
 }
 
-const Board: React.FC<BoardProps> = ({ board, validMoves, onCellClick }) => {
+const Board: React.FC<BoardProps> = ({ board, validMoves, onCellClick, animations }) => {
   return (
     <table id="board">
       <tbody>
@@ -16,14 +28,26 @@ const Board: React.FC<BoardProps> = ({ board, validMoves, onCellClick }) => {
           <tr key={y}>
             {row.map((cell, x) => {
               const isHint = validMoves.some(m => m.x === x && m.y === y);
+              const isPlaced = animations?.placed && animations.placed.x === x && animations.placed.y === y;
+              const flip = animations?.flips.find(f => f.x === x && f.y === y);
               return (
                 <td
                   key={x}
                   onClick={() => onCellClick(x, y)}
                   className={isHint ? 'hint' : ''}
                 >
-                  {cell === 1 && <div className="piece black" />}
-                  {cell === 2 && <div className="piece white" />}
+                  {cell === 1 && (
+                    <div
+                      className={`piece black${isPlaced ? ' pop' : ''}${flip ? ' flip' : ''}`}
+                      style={flip ? { animationDelay: `${flip.delay}ms` } : undefined}
+                    />
+                  )}
+                  {cell === 2 && (
+                    <div
+                      className={`piece white${isPlaced ? ' pop' : ''}${flip ? ' flip' : ''}`}
+                      style={flip ? { animationDelay: `${flip.delay}ms` } : undefined}
+                    />
+                  )}
                 </td>
               );
             })}

--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,26 @@ td {
   border-radius: 50%;
   margin: auto;
   margin-top: 10%;
+  transform-style: preserve-3d;
+}
+
+@keyframes pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+.pop {
+  animation: pop 0.3s ease-out;
+}
+
+@keyframes flip {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(180deg); }
+}
+
+.flip {
+  animation: flip 0.4s ease-out forwards;
 }
 
 .black {


### PR DESCRIPTION
## Summary
- animate newly placed stones with a pop effect
- sequentially flip stones with delays
- hook animation data into Board rendering
- add CSS keyframes for pop and flip animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68563299e1148330a2230a8e5e9f4241