### PR TITLE
Allow CPU to think during board animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -251,7 +251,7 @@ function App() {
   }, [turn, board, gameOver, mode, actualPlayerColor, onlineState.validMoves, animating]);
 
   useEffect(() => {
-    if ((mode !== 'cpu' && mode !== 'cpu-cpu') || gameOver || cpuThinking || animating) return;
+    if ((mode !== 'cpu' && mode !== 'cpu-cpu') || gameOver || cpuThinking) return;
     if (mode === 'cpu' && turn !== (3 - actualPlayerColor)) return;
     const moves = getValidMoves(turn, board);
     if (moves.length === 0) return;


### PR DESCRIPTION
## Summary
- let the CPU worker start calculating while the board animation plays

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856732fb4548330a8a1fa4f74346831