### PR TITLE
Clear cache between matches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
     return b;
   };
 
-  const { calculateMove } = useCpuWorker();
+  const { calculateMove, reset } = useCpuWorker();
   const [mode, setMode] = useState<Mode>('title');
   // const [cpuLevel, setCpuLevel] = useState<number>(1);
   const [cpuLevel, setCpuLevel] = useState<keyof typeof AI_CONFIG>(1);
@@ -124,6 +124,7 @@ function App() {
 
   useEffect(() => {
     if (mode === 'cpu') {
+      reset();
       TIMING_CONFIG.cpuDelayMs = DEFAULT_CPU_DELAY_MS;
       const resolved = resolvePlayerColor();
       setActualPlayerColor(resolved);
@@ -138,6 +139,7 @@ function App() {
       setGameOver(false);
       setMessage('黒の番です');
     } else if (mode === 'cpu-cpu') {
+      reset();
       TIMING_CONFIG.cpuDelayMs = cpuDelay;
       setCpu1ActualColor(cpu1Color === 'black' ? 1 : 2);
       setBoard(createInitialBoard());
@@ -327,6 +329,7 @@ function App() {
   };
 
   const restartGame = () => {
+    reset();
     const resolved = randomRef.current ? resolvePlayerColor() : (playerColor === 'black' ? 1 : 2);
     setActualPlayerColor(resolved);
     const firstTurn = 1;
@@ -367,6 +370,7 @@ function App() {
     } else {
       setCurrentMatch(c => c + 1);
       setTimeout(() => {
+        reset();
         setBoard(createInitialBoard());
         setTurn(1);
         setGameOver(false);

--- a/src/ai/ai.ts
+++ b/src/ai/ai.ts
@@ -7,6 +7,12 @@ const transpositionTable = new Map<string, number>();
 // transposition table for endgame solver
 const endgameTranspositionTable = new Map<string, number>();
 
+// Allow external modules to clear cached search results
+export function clearTranspositionTables(): void {
+  transpositionTable.clear();
+  endgameTranspositionTable.clear();
+}
+
 // more efficient board hashing than JSON.stringify for flat board
 function hashBoard(board: Board): string {
   let key = '';

--- a/src/hooks/useCpuWorker.ts
+++ b/src/hooks/useCpuWorker.ts
@@ -25,6 +25,13 @@ export function useCpuWorker() {
     return workerRef.current;
   };
 
+  const reset = () => {
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+  };
+
   const calculateMove = (data: CpuRequest): Promise<CpuResponse> => {
     return new Promise((resolve) => {
       const worker = createWorker();
@@ -37,5 +44,5 @@ export function useCpuWorker() {
     });
   };
 
-  return { calculateMove };
+  return { calculateMove, reset };
 }


### PR DESCRIPTION
## Summary
- reset worker on each new game start
- expose reset helper in `useCpuWorker`
- document automatic cache reset (removed per feedback)

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68594e12e6a48330b519e3bdda407dc6