### PR TITLE
Display build time on title screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ npm run dev
 オンライン対戦機能では Colyseus サーバー
 `wss://othello-server-11z5.onrender.com` を利用します。
 接続先は環境変数 `VITE_ONLINE_SERVER_URL` で上書き可能です（例: `ws://localhost:2567`）。
+
+### ビルド日時の表示
+
+タイトル画面の下部に、アプリをビルドした日時が表示されます。Vite の `define` オプションで注入された `__BUILD_TIME__` 定数を利用しています。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -391,6 +391,9 @@ function App() {
             <button onClick={() => setMode('online-select')}>オンライン対戦</button>
           </div>
         </div>
+        <p id="build-time">
+          ビルド日時: {new Date(__BUILD_TIME__).toLocaleString()}
+        </p>
       </div>
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -128,3 +128,9 @@ td {
   font-weight: bold;
 }
 
+#build-time {
+  font-size: 0.8em;
+  color: #666;
+  margin-top: 20px;
+}
+

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,5 @@
 /// <reference types="vite/client" />
 
 declare module '*.css';
+
+declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   base: '/othello_React/',
   plugins: [react()],
+  define: {
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
 })


### PR DESCRIPTION
## Summary
- inject build time constant via `vite.config.ts`
- expose `__BUILD_TIME__` in TypeScript environment declarations
- show build time at the bottom of the title screen
- style the build time text
- document build time display in the README

## Testing
- `npm run lint` *(fails: unexpected any in various files)*

------
https://chatgpt.com/codex/tasks/task_e_685a769263748330a30a5c0c447fbc78