### PR TITLE
Fix piece centering

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -68,6 +68,7 @@ td {
   position: relative;
   text-align: center;
   vertical-align: middle;
+  perspective: 800px;
 }
 
 .piece {
@@ -77,6 +78,9 @@ td {
   display: block;
   margin: auto;
   transform-style: preserve-3d;
+  transform: rotateY(0deg);
+  transform-origin: center;
+  backface-visibility: hidden;
 }
 
 @keyframes pop {


### PR DESCRIPTION
## Summary
- `td` と `.piece` のスタイルを更新し、石の表示位置を改善

## Testing
- `npm run lint` *(失敗)*
- `npm run build` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8392ef883308418603902e150ec