### PR TITLE
Refactor board cells into components

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import type { Board as BoardState } from '../types';
+import Cell from './Cell';
 
 interface FlipAnim {
   x: number;
@@ -32,24 +33,16 @@ const BoardComponent: FC<BoardProps> = ({ board, validMoves, onCellClick, animat
               const isPlaced = animations?.placed && animations.placed.x === x && animations.placed.y === y;
               const flip = animations?.flips.find(f => f.x === x && f.y === y);
               return (
-                <td
+                <Cell
                   key={x}
-                  onClick={() => onCellClick(x, y)}
-                  className={isHint ? 'hint' : ''}
-                >
-                  {cell === 1 && (
-                    <div
-                      className={`piece black${isPlaced ? ' pop' : ''}${flip ? ' flip' : ''}`}
-                      style={flip ? { animationDelay: `${flip.delay}ms` } : undefined}
-                    />
-                  )}
-                  {cell === 2 && (
-                    <div
-                      className={`piece white${isPlaced ? ' pop' : ''}${flip ? ' flip' : ''}`}
-                      style={flip ? { animationDelay: `${flip.delay}ms` } : undefined}
-                    />
-                  )}
-                </td>
+                  x={x}
+                  y={y}
+                  cell={cell}
+                  isHint={isHint}
+                  isPlaced={Boolean(isPlaced)}
+                  flipDelay={flip?.delay}
+                  onClick={onCellClick}
+                />
               );
             })}
           </tr>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,0 +1,21 @@
+import type { FC } from 'react';
+import Piece from './Piece';
+
+interface CellProps {
+  x: number;
+  y: number;
+  cell: number;
+  isHint: boolean;
+  isPlaced: boolean;
+  flipDelay?: number;
+  onClick: (x: number, y: number) => void;
+}
+
+const Cell: FC<CellProps> = ({ x, y, cell, isHint, isPlaced, flipDelay, onClick }) => (
+  <td onClick={() => onClick(x, y)} className={isHint ? 'hint' : ''}>
+    {cell === 1 && <Piece color="black" isPlaced={isPlaced} flipDelay={flipDelay} />}
+    {cell === 2 && <Piece color="white" isPlaced={isPlaced} flipDelay={flipDelay} />}
+  </td>
+);
+
+export default Cell;

--- a/src/components/Piece.tsx
+++ b/src/components/Piece.tsx
@@ -1,0 +1,16 @@
+import type { FC } from 'react';
+
+interface PieceProps {
+  color: 'black' | 'white';
+  isPlaced?: boolean;
+  flipDelay?: number;
+}
+
+const Piece: FC<PieceProps> = ({ color, isPlaced, flipDelay }) => (
+  <div
+    className={`piece ${color}${isPlaced ? ' pop' : ''}${flipDelay !== undefined ? ' flip' : ''}`}
+    style={flipDelay !== undefined ? { animationDelay: `${flipDelay}ms` } : undefined}
+  />
+);
+
+export default Piece;


### PR DESCRIPTION
## Summary
- extract `Piece` component for rendering stone pieces
- extract `Cell` component for each board cell
- use these components from `Board`

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ab89483c08330ad8d68ee0970e9cf