### PR TITLE
Add CPU abort logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,6 +179,14 @@ function App() {
   }, [mode]);
 
   useEffect(() => {
+    return () => {
+      if (mode === 'cpu') {
+        abortCpu();
+      }
+    };
+  }, [mode]);
+
+  useEffect(() => {
     if (mode !== 'online') return;
     const newBoard = onlineState.board.length ? onlineState.board : createInitialBoard();
     if (prevOnlineBoardRef.current.length === SIZE * SIZE && newBoard.length === SIZE * SIZE) {
@@ -338,6 +346,15 @@ function App() {
     setGameOver(false);
     animEndRef.current = Date.now();
     setMessage(firstTurn === 1 ? '黒の番です' : '白の番です');
+  };
+
+  const abortCpu = () => {
+    if (cpuTimeoutRef.current) {
+      clearTimeout(cpuTimeoutRef.current);
+      cpuTimeoutRef.current = null;
+    }
+    reset();
+    setCpuThinking(false);
   };
 
   const abortCpuCpu = (next: Mode = 'cpu-cpu-result') => {
@@ -663,6 +680,9 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
                 abortCpuCpu('title');
               } else if (mode === 'online') {
                 disconnectOnline(true);
+                setMode('title');
+              } else if (mode === 'cpu') {
+                abortCpu();
                 setMode('title');
               } else {
                 setMode('title');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,7 @@ function App() {
   useEffect(() => {
     if (mode === 'cpu') {
       reset();
+      cpuCpuCancelRef.current = false;
       TIMING_CONFIG.cpuDelayMs = DEFAULT_CPU_DELAY_MS;
       const resolved = resolvePlayerColor();
       setActualPlayerColor(resolved);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -348,6 +348,12 @@ function App() {
     setMessage(firstTurn === 1 ? '黒の番です' : '白の番です');
   };
 
+  const initBoard = () => {
+    setBoard(createInitialBoard());
+    setTurn(1);
+    setGameOver(false);
+  };
+
   const abortCpu = () => {
     if (cpuTimeoutRef.current) {
       clearTimeout(cpuTimeoutRef.current);
@@ -454,7 +460,14 @@ function App() {
             </label>
           </div>
           <div style={{ marginTop: 16 }}>
-            <button onClick={() => setMode('cpu')}>対戦開始</button>
+            <button
+              onClick={() => {
+                initBoard();
+                setMode('cpu');
+              }}
+            >
+              対戦開始
+            </button>
             <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>戻る</button>
           </div>
         </div>
@@ -543,7 +556,14 @@ function App() {
             </label>
           </div>
           <div style={{ marginTop: 16 }}>
-            <button onClick={() => setMode('cpu-cpu')}>開始</button>
+            <button
+              onClick={() => {
+                initBoard();
+                setMode('cpu-cpu');
+              }}
+            >
+              開始
+            </button>
             <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>戻る</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `abortCpu` to stop CPU games
- invoke `abortCpu` when leaving CPU mode
- automatically abort on mode change

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685abee563dc833096218c404ea347ac