### PR TITLE
Add settings menu with localization and theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>オセロ</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "colyseus.js": "^0.16.19",
+        "i18next": "^25.2.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-i18next": "^15.5.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -263,6 +265,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2728,6 +2739,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3355,6 +3406,32 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.3.tgz",
+      "integrity": "sha512-ypYmOKOnjqPEJZO4m1BI0kS8kWqkBNsKYyhVUfij0gvjy9xJNoG/VcGkxq5dRlVwzmrmY1BQMAmpbbUBLwC4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3682,7 +3759,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3867,6 +3944,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "deploy": "npm run build && gh-pages -d dist"
   },
   "dependencies": {
+    "colyseus.js": "^0.16.19",
+    "i18next": "^25.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "colyseus.js": "^0.16.19"
+    "react-i18next": "^15.5.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState, useRef } from 'react';
 import BoardComponent from './components/Board';
+import SettingsMenu from './components/SettingsMenu';
 import './style.css';
 import { getValidMoves, countStones, index } from './logic/game';
 import { AI_CONFIG, TIMING_CONFIG } from './ai/config';
 import { useCpuWorker } from './hooks/useCpuWorker';
 import { useOnlineGame } from './hooks/useOnlineGame';
+import { useTranslation } from 'react-i18next';
 import type { Board as BoardState } from './types';
 
 const DEFAULT_CPU_DELAY_MS = TIMING_CONFIG.cpuDelayMs;
@@ -34,6 +36,7 @@ type Mode =
   | 'cpu-cpu-result';
 
 function App() {
+  const { t } = useTranslation();
   const createInitialBoard = (): BoardState => {
     const b = new Uint8Array(SIZE * SIZE) as BoardState;
     b[index(3,3)] = 2; b[index(4,3)] = 1;
@@ -405,18 +408,19 @@ function App() {
   if (mode === 'title') {
     return (
       <div>
-        <h1>オセロ</h1>
+        <SettingsMenu />
+        <h1>{t('title')}</h1>
         <div id="mode-selection">
-          <h2>モードを選択してください</h2>
+          <h2>{t('selectMode')}</h2>
           <div className="mode-buttons">
-            <button onClick={() => setMode('cpu-select')}>CPU対戦</button>
-            <button onClick={() => setMode('cpu-cpu-select')}>CPU vs CPU</button>
-            <button onClick={() => setMode('pvp')}>2人対戦</button>
-            <button onClick={() => setMode('online-select')}>オンライン対戦</button>
+            <button onClick={() => setMode('cpu-select')}>{t('cpuMatch')}</button>
+            <button onClick={() => setMode('cpu-cpu-select')}>{t('cpuVsCpu')}</button>
+            <button onClick={() => setMode('pvp')}>{t('twoPlayers')}</button>
+            <button onClick={() => setMode('online-select')}>{t('onlineMatch')}</button>
           </div>
         </div>
         <p id="build-time">
-          ビルド日時: {new Date(__BUILD_TIME__).toLocaleString()}
+          {t('buildTime')}: {new Date(__BUILD_TIME__).toLocaleString()}
         </p>
       </div>
     );
@@ -425,10 +429,11 @@ function App() {
   if (mode === 'cpu-select') {
     return (
       <div>
+        <SettingsMenu />
         <h1>CPU対戦設定</h1>
         <div>
           <label>
-            CPUレベル：
+            CPUレベル:
             <select
               value={cpuLevel}
               onChange={(e) => setCpuLevel(Number(e.target.value))}
@@ -467,9 +472,9 @@ function App() {
                 setMode('cpu');
               }}
             >
-              対戦開始
+              {t('start')}
             </button>
-            <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>戻る</button>
+            <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>{t('back')}</button>
           </div>
         </div>
       </div>
@@ -479,6 +484,7 @@ function App() {
   if (mode === 'cpu-cpu-select') {
     return (
       <div>
+        <SettingsMenu />
         <h1>CPU vs CPU 設定</h1>
         <div>
           <label>
@@ -563,9 +569,9 @@ function App() {
                 setMode('cpu-cpu');
               }}
             >
-              開始
+              {t('start')}
             </button>
-            <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>戻る</button>
+            <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>{t('back')}</button>
           </div>
         </div>
       </div>
@@ -575,7 +581,8 @@ function App() {
   if (mode === 'online-select') {
     return (
       <div>
-        <h1>オンライン対戦</h1>
+        <SettingsMenu />
+        <h1>{t('onlineMatch')}</h1>
         <div style={{ marginTop: 16 }}>
           <button
             onClick={() => {
@@ -602,7 +609,7 @@ function App() {
             合言葉で対戦
           </button>
         </div>
-        <button onClick={() => setMode('title')} style={{ marginTop: 16 }}>戻る</button>
+        <button onClick={() => setMode('title')} style={{ marginTop: 16 }}>{t('back')}</button>
       </div>
     );
   }
@@ -638,14 +645,15 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
 
     return (
       <div>
+        <SettingsMenu />
         <h1>結果</h1>
         <pre style={{ whiteSpace: 'pre-wrap' }}>{summary}</pre>
         <button onClick={download}>結果をダウンロード</button>
         <button onClick={() => setMode('cpu-cpu-select')} style={{ marginLeft: 8 }}>
-          設定に戻る
+          {t('back')}
         </button>
         <button onClick={() => setMode('title')} style={{ marginLeft: 8 }}>
-          タイトルに戻る
+          {t('back')}
         </button>
       </div>
     );
@@ -654,6 +662,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
   if (mode === 'online' && onlineState.waiting) {
     return (
       <div>
+        <SettingsMenu />
         <h1>マッチング中...</h1>
         <p>対戦相手を待っています</p>
         <button
@@ -662,7 +671,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
             setMode('online-select');
           }}
         >
-          キャンセル
+          {t('back')}
         </button>
       </div>
     );
@@ -672,7 +681,8 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
     const { black: blackCount, white: whiteCount } = countStones(board);
     return (
       <div>
-        <h1>オセロ</h1>
+        <SettingsMenu />
+        <h1>{t('title')}</h1>
         <p style={{ fontWeight: 'bold' }}>
           {mode === 'online'
             ? 'オンライン対戦'
@@ -692,7 +702,7 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
         <p id="score-board">黒:{blackCount} 白:{whiteCount}</p>
         <p>{message}</p>
         {mode === 'online' && !gameOver && (
-          <button onClick={giveUpOnline}>降参</button>
+          <button onClick={giveUpOnline}>{t('giveup')}</button>
         )}
         {(mode !== 'online' || gameOver) && (
           <button
@@ -709,22 +719,22 @@ AI2（${cpu1ActualColor === 1 ? '白' : '黒'}）: ${AI_CONFIG[cpu2Level]?.name}
                 setMode('title');
               }
             }}>
-           タイトルに戻る
+           {t('back')}
           </button>
         )}
         {(mode === 'cpu' || mode === 'pvp') && gameOver && (
           <button onClick={restartGame} style={{ marginLeft: 8 }}>
-            再戦する
+            {t('resume')}
           </button>
         )}
         {mode === 'online' && gameOver && (
           <button onClick={reconnectOnline} style={{ marginLeft: 8 }}>
-            再戦する
+            {t('resume')}
           </button>
         )}
         {mode === 'cpu-cpu' && (
           <button onClick={() => abortCpuCpu()} style={{ marginLeft: 8 }}>
-            中止
+            {t('stop')}
           </button>
         )}
       </div>

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSettings } from '../hooks/useSettings';
+import type { ThemeMode } from '../hooks/useSettings';
+import '../style.css';
+
+const SettingsMenu = () => {
+  const { t, i18n } = useTranslation();
+  const { language, setLanguage, playerName, setPlayerName, theme, setTheme } = useSettings();
+  const [open, setOpen] = useState(false);
+  const toggle = () => setOpen(!open);
+
+  const changeLang = (lang: 'ja' | 'en') => {
+    setLanguage(lang);
+    i18n.changeLanguage(lang);
+  };
+
+  return (
+    <>
+      <button id="menu-btn" onClick={toggle}>☰</button>
+      <div id="menu" className={open ? 'open' : ''}>
+        <label>
+          {t('language')}:
+          <select value={language} onChange={e => changeLang(e.target.value as 'ja' | 'en')}>
+            <option value="ja">日本語</option>
+            <option value="en">English</option>
+          </select>
+        </label>
+        <label>
+          {t('playerName')}:
+          <input value={playerName} onChange={e => setPlayerName(e.target.value)} />
+        </label>
+        <label>
+          {t('theme')}:
+          <select value={theme} onChange={e => setTheme(e.target.value as ThemeMode)}>
+            <option value="light">{t('light')}</option>
+            <option value="dark">{t('dark')}</option>
+            <option value="system">{t('system')}</option>
+          </select>
+        </label>
+      </div>
+    </>
+  );
+};
+
+export default SettingsMenu;

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useEffect, useState, type FC } from 'react';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+interface SettingsState {
+  language: 'ja' | 'en';
+  playerName: string;
+  theme: ThemeMode;
+  setLanguage: (lang: 'ja' | 'en') => void;
+  setPlayerName: (name: string) => void;
+  setTheme: (theme: ThemeMode) => void;
+}
+
+const SettingsContext = createContext<SettingsState | undefined>(undefined);
+const STORAGE_KEY = 'othello_settings';
+
+export const SettingsProvider: FC<{children: React.ReactNode}> = ({ children }) => {
+  const [language, setLanguage] = useState<'ja' | 'en'>('ja');
+  const [playerName, setPlayerName] = useState('Player');
+  const [theme, setTheme] = useState<ThemeMode>('system');
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        if (data.language) setLanguage(data.language);
+        if (data.playerName) setPlayerName(data.playerName);
+        if (data.theme) setTheme(data.theme);
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ language, playerName, theme }));
+  }, [language, playerName, theme]);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  useEffect(() => {
+    const applyTheme = () => {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const actual = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme;
+      document.body.dataset.theme = actual;
+    };
+    applyTheme();
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => theme === 'system' && applyTheme();
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  return (
+    <SettingsContext.Provider value={{ language, playerName, theme, setLanguage, setPlayerName, setTheme }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('SettingsProvider missing');
+  return ctx;
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,58 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  ja: {
+    translation: {
+      title: 'オセロ',
+      selectMode: 'モードを選択してください',
+      cpuMatch: 'CPU対戦',
+      cpuVsCpu: 'CPU vs CPU',
+      twoPlayers: '2人対戦',
+      onlineMatch: 'オンライン対戦',
+      buildTime: 'ビルド日時',
+      back: '戻る',
+      start: '開始',
+      language: '言語',
+      playerName: 'プレイヤー名',
+      theme: 'テーマ',
+      light: 'ライト',
+      dark: 'ダーク',
+      system: 'システム',
+      resume: '再戦する',
+      giveup: '降参',
+      stop: '中止',
+    },
+  },
+  en: {
+    translation: {
+      title: 'Othello',
+      selectMode: 'Select Mode',
+      cpuMatch: 'CPU Match',
+      cpuVsCpu: 'CPU vs CPU',
+      twoPlayers: '2 Players',
+      onlineMatch: 'Online Match',
+      buildTime: 'Build Time',
+      back: 'Back',
+      start: 'Start',
+      language: 'Language',
+      playerName: 'Player Name',
+      theme: 'Theme',
+      light: 'Light',
+      dark: 'Dark',
+      system: 'System',
+      resume: 'Play Again',
+      giveup: 'Give Up',
+      stop: 'Stop',
+    },
+  },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'ja',
+  fallbackLng: 'ja',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './style.css';
+import './i18n';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './i18n';
+import { SettingsProvider } from './hooks/useSettings';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <I18nextProvider i18n={i18n}>
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </I18nextProvider>
   </React.StrictMode>
 );

--- a/src/style.css
+++ b/src/style.css
@@ -134,3 +134,56 @@ td {
   margin-top: 20px;
 }
 
+
+/* Theme colors */
+body[data-theme='dark'] {
+  background-color: #222;
+  color: #eee;
+}
+body[data-theme='light'] {
+  background-color: #f2f2f2;
+  color: #333;
+}
+
+#menu-btn {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  z-index: 1000;
+  font-size: 24px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+#menu {
+  position: fixed;
+  top: 0;
+  right: -220px;
+  width: 200px;
+  height: 100%;
+  background-color: var(--menu-bg, #fff);
+  box-shadow: -2px 0 5px rgba(0,0,0,0.3);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: right 0.3s;
+  z-index: 999;
+}
+
+body[data-theme='dark'] #menu {
+  background-color: #333;
+  color: #eee;
+}
+
+#menu.open {
+  right: 0;
+}
+
+#menu label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -187,3 +187,4 @@ body[data-theme='dark'] #menu {
   align-items: flex-start;
   gap: 4px;
 }
+body[data-theme='dark'] h1 { color: #eee; }

--- a/src/style.css
+++ b/src/style.css
@@ -134,6 +134,14 @@ td {
   margin-top: 20px;
 }
 
+body[data-theme='dark'] #message {
+  color: #ccc;
+}
+
+body[data-theme='dark'] #build-time {
+  color: #aaa;
+}
+
 
 /* Theme colors */
 body[data-theme='dark'] {


### PR DESCRIPTION
## Summary
- introduce react-i18next setup for Japanese/English
- create SettingsMenu component for language, theme, player name
- persist user settings to localStorage with new provider
- support dark and light themes
- show hamburger menu on each screen

## Testing
- `npm run lint` *(fails: several TypeScript lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d58da03588330906e37bc0cb9a46b