### PR TITLE
Clear transposition table when CPU worker resets

### DIFF
--- a/src/hooks/useCpuWorker.ts
+++ b/src/hooks/useCpuWorker.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import type { Board } from '../types';
+import { clearTranspositionTables } from '../ai/ai';
 
 export type CpuRequest = {
   board: Board;
@@ -30,6 +31,7 @@ export function useCpuWorker() {
       workerRef.current.terminate();
       workerRef.current = null;
     }
+    clearTranspositionTables();
   };
 
   const calculateMove = (data: CpuRequest): Promise<CpuResponse> => {


### PR DESCRIPTION
## Summary
- clear AI transposition table in `useCpuWorker` reset

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ebdd40d608330b89a8b6294b640e3