### PR TITLE
Add abort support for CPU worker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
     return b;
   };
 
-  const { calculateMove, reset } = useCpuWorker();
+  const { calculateMove, reset, abort } = useCpuWorker();
   const [mode, setMode] = useState<Mode>('title');
   // const [cpuLevel, setCpuLevel] = useState<number>(1);
   const [cpuLevel, setCpuLevel] = useState<keyof typeof AI_CONFIG>(1);
@@ -363,6 +363,7 @@ function App() {
       clearTimeout(cpuTimeoutRef.current);
       cpuTimeoutRef.current = null;
     }
+    abort();
     reset();
     setCpuThinking(false);
   };
@@ -373,6 +374,7 @@ function App() {
       clearTimeout(cpuTimeoutRef.current);
       cpuTimeoutRef.current = null;
     }
+    abort();
     setCpuThinking(false);
     setGameOver(true);
     setCurrentMatch(numMatches);
@@ -397,6 +399,7 @@ function App() {
     } else {
       setCurrentMatch(c => c + 1);
       setTimeout(() => {
+        abort();
         reset();
         setBoard(createInitialBoard());
         setTurn(1);

--- a/src/workers/cpuWorker.ts
+++ b/src/workers/cpuWorker.ts
@@ -1,11 +1,18 @@
 import { cpuMove } from '../ai/ai';
 import type { Board } from '../types';
 
-export type CpuRequest = {
+export type CpuStartRequest = {
+  type: 'start';
   board: Board;
   turn: 1 | 2;
   level: number;
 };
+
+export type CpuAbortRequest = {
+  type: 'abort';
+};
+
+export type CpuRequest = CpuStartRequest | CpuAbortRequest;
 
 export type CpuResponse = {
   x: number;
@@ -13,10 +20,31 @@ export type CpuResponse = {
   flips: [number, number][];
 } | null;
 
+let controller: AbortController | null = null;
+
 self.onmessage = function (e: MessageEvent<CpuRequest>) {
-  const { board, turn, level } = e.data;
-  const move = cpuMove(board, turn, level);
-  postMessage(move);
+  const data = e.data;
+  if (data.type === 'abort') {
+    controller?.abort();
+    controller = null;
+    return;
+  }
+
+  if (data.type === 'start') {
+    controller?.abort();
+    controller = new AbortController();
+    try {
+      const move = cpuMove(data.board, data.turn, data.level, controller.signal);
+      postMessage(move);
+    } catch (err) {
+      if ((err as any).name !== 'AbortError') {
+        // Unexpected error; rethrow
+        throw err;
+      }
+    } finally {
+      controller = null;
+    }
+  }
 };
 
 export {};


### PR DESCRIPTION
## Summary
- handle abort and start messages in `cpuWorker`
- expose `abort` in `useCpuWorker`
- send abort commands when cancelling CPU calculations
- propagate abort through AI search functions

## Testing
- `npm run lint` *(fails: ESLint found issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ec0b582208330aa7a48fdf2ddc7f4